### PR TITLE
Fix broken link to Rust homepage.

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@ header {
         <img src="rust-logo-blk.svg" width="128" height="128">
       </div>
       <div class="large-11 columns">
-          <p><a href="https://rust-lang.org">Crafted with Rust</a>. Built on <a href="https://matrix.org">Matrix</a>. Only Free Software used.
+          <p><a href="https://www.rust-lang.org">Crafted with Rust</a>. Built on <a href="https://matrix.org">Matrix</a>. Only Free Software used.
           <p>Made with <span class="love">❤</span> in <a href="https://hackerbots.net">Oakland, California</a>
           <p>We love the <a href="http://contributor-covenant.org/">Contributor
             Covenant</a> and so should you.


### PR DESCRIPTION
Unfortunately, the site requires 'www' with HTTPS at the moment.