### PR TITLE
Fix privacy warnings.

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -235,7 +235,7 @@ impl Room {
 
 
 impl Bridge {
-    pub fn room_from_matrix(&mut self, id: &matrix::model::RoomID) -> &mut Room {
+    fn room_from_matrix(&mut self, id: &matrix::model::RoomID) -> &mut Room {
         if !self.rooms.contains_key(id) {
             self.rooms.insert(id.clone(), Room::new(id.clone()));
         }
@@ -245,7 +245,7 @@ impl Bridge {
         }
     }
 
-    pub fn room_from_irc(&mut self, id: &String) -> Option<&mut Room> {
+    fn room_from_irc(&mut self, id: &String) -> Option<&mut Room> {
         let mut room_id: Option<matrix::model::RoomID> = None;
         for (_, r) in self.rooms.iter_mut() {
             if let Some(ref alias) = r.irc_name {


### PR DESCRIPTION
Using the latest nightly compiler (1.8.0), these warnings are generated compiling PTO:

```
src/bridge.rs:238:76: 238:80 warning: private type in public interface, #[warn(private_in_public)] on by default
src/bridge.rs:238     pub fn room_from_matrix(&mut self, id: &matrix::model::RoomID) -> &mut Room {
                                                                                             ^~~~
src/bridge.rs:238:76: 238:80 warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
src/bridge.rs:238:76: 238:80 note: for more information, see the explanation for E0446 (`--explain E0446`)
src/bridge.rs:248:65: 248:69 warning: private type in public interface, #[warn(private_in_public)] on by default
src/bridge.rs:248     pub fn room_from_irc(&mut self, id: &String) -> Option<&mut Room> {
                                                                                  ^~~~
src/bridge.rs:248:65: 248:69 warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
src/bridge.rs:248:65: 248:69 note: for more information, see the explanation for E0446 (`--explain E0446`)
```

This PR fixes the warnings (which are going to be an error) by removing the `pub` qualifier on these to functions, as they do not seem to need it.